### PR TITLE
feat: Toogle Feed Rate Precision (Ft/min <-> in/min, M/min <-> mm/min)

### DIFF
--- a/rcp/components/home/coordbar.kv
+++ b/rcp/components/home/coordbar.kv
@@ -30,16 +30,18 @@
         halign: 'right'
         valign: 'center'
         on_release: root.update_position()
-      Label:
+      Button:
         size_hint_y: 0.3
         font_name: "fonts/iosevka-regular.ttf"
         font_size: self.height / 1.5
         font_style: "bold"
+        background_color: (0,0,0,1)
         color: app.formats.display_color
         text: root.formattedSpeed
         text_size: self.size
         halign: 'right'
         valign: 'top'
+        on_release: root.toggle_speed_mode()
 
     BoxLayout:
       size_hint_x: None

--- a/rcp/components/home/coordbar.py
+++ b/rcp/components/home/coordbar.py
@@ -73,6 +73,7 @@ class CoordBar(BoxLayout, SavingDispatcher):
         self.app.bind(currentOffset=self.update_scaledPosition)
         self.app.formats.bind(factor=self.update_scaledPosition)
         self.app.formats.bind(factor=self.set_sync_ratio)
+        self.app.formats.bind(speed_conversion_factor=self.update_scaledPosition)
         self.app.bind(connected=self.init_connection)
         self.app.bind(update_tick=self.update_tick)
         self.bind(position=self.update_scaledPosition)
@@ -169,7 +170,13 @@ class CoordBar(BoxLayout, SavingDispatcher):
             ) * self.app.formats.factor
 
             self.formattedPosition = self.app.formats.position_format.format(self.scaledPosition)
-            self.formattedSpeed = self.app.formats.speed_format.format(self.speed)
+            displayed_speed = self.speed * self.app.formats.speed_conversion_factor
+            self.formattedSpeed = self.app.formats.speed_format.format(displayed_speed)
+
+    def toggle_speed_mode(self):
+        self.app.beep()
+        self.app.formats.toggle_speed_mode()
+        self.update_scaledPosition()
 
     def on_newPosition(self, instance, value):
         self.set_current_position(value)

--- a/rcp/dispatchers/formats.py
+++ b/rcp/dispatchers/formats.py
@@ -17,7 +17,9 @@ class FormatsDispatcher(SavingDispatcher):
         'accept_color',
         'cancel_color',
         'color_on',
-        'color_off'
+        'color_off',
+        'metric_speed_mode',
+        'imperial_speed_mode'
     ]
 
     metric_position = StringProperty("{:+0.3f}")
@@ -36,6 +38,10 @@ class FormatsDispatcher(SavingDispatcher):
     position_format = StringProperty()
     factor = ObjectProperty(Fraction(1, 1))
 
+    metric_speed_mode = BooleanProperty(True)
+    imperial_speed_mode = BooleanProperty(False)
+    speed_conversion_factor = NumericProperty(1.0)
+
     display_color = ColorProperty("#ffcc35ff")
     accept_color = ColorProperty("#32ff32ff")
     cancel_color = ColorProperty("#ff3232ff")
@@ -53,13 +59,32 @@ class FormatsDispatcher(SavingDispatcher):
 
     def update_format(self, *args, **kv):
         if self.current_format == "MM":
+            if self.metric_speed_mode:
+                self.speed_format = f"{self.metric_speed} M/min"
+                self.speed_conversion_factor = 1.0
+            else:
+                self.speed_format = f"{self.metric_speed} mm/min"
+                self.speed_conversion_factor = 1000
             self.speed_format = f"{self.metric_speed} M/min"
             self.position_format = self.metric_position
             self.factor = Fraction(1, 1)
         else:
+            if self.imperial_speed_mode:
+                self.speed_format = f"{self.imperial_speed} in/min"
+                self.speed_conversion_factor = 1.0
+            else:
+                self.speed_format = f"{self.imperial_speed} Ft/min"
+                self.speed_conversion_factor = 12.0
             self.speed_format = f"{self.imperial_speed} Ft/min"
             self.position_format = self.imperial_position
             self.factor = Fraction(10, 254)
+
+    def toggle_speed_mode(self):
+        if self.current_format == "MM":
+            self.metric_speed_mode = not self.metric_speed_mode
+        else:
+            self.imperial_speed_mode = not self.imperial_speed_mode
+        self.update_format()
 
     def toggle(self, *_):
         if self.current_format == "MM":


### PR DESCRIPTION
### Summary

Add functionality to the DRO interface that allows users to toggle between different feed rate display formats by pressing the feed rate display. This includes switching between **mm/min & M/min** and **in/min & Ft/min**.

### Details

- On each click, switch between:
  - **Metric mode:** mm/min and M/min
  - **Imperial mode:** in/min and Ft/min
- Update the displayed labels and values immediately on toggle.

Closes: #38 
---

**Labels:** `enhancement`
