### PR TITLE
feat: support unicode character escape sequence parsing

### DIFF
--- a/rcp/components/widgets/string_item.kv
+++ b/rcp/components/widgets/string_item.kv
@@ -24,4 +24,4 @@
       valign: "center"
       halign: "center"
       disabled: root.disabled
-      on_text_validate: root.value = self.text
+      on_text_validate: root.set_value_from_text(self.text)

--- a/rcp/components/widgets/string_item.py
+++ b/rcp/components/widgets/string_item.py
@@ -14,3 +14,9 @@ class StringItem(BoxLayout):
     value = StringProperty("")
     disabled = BooleanProperty(False)
     help_file = StringProperty("")
+
+    def set_value_from_text(self, text: str):
+        try:
+            self.value = text.encode("raw_unicode_escape").decode("unicode_escape")
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            self.value = text


### PR DESCRIPTION
This is a simple change to enable parsing unicode escape sequences upon string_item entry.  The motivation was to add support for unicode characters for Axis names, for instance using a diameter symbol (e.g \u2300, \u00d8, \u00f8 etc.) for a lathe cross-slide axis rather than 'X'.

<img width="797" height="592" alt="image" src="https://github.com/user-attachments/assets/d6364539-eb66-4236-ae46-18573b1fc999" />
