### PR TITLE
Reenable beep on touch for buttons (but not empty space)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "minimalmodbus>=2.1.1",
     "nmcli>=1.5.0",
     "pydantic>=2.10.3",
+    "pygame>=2.0.0",
     "pyyaml>=6.0.2",
     "aiohttp>=3.9.0",
     "sentry-sdk>=2.32.0",

--- a/rcp/app.py
+++ b/rcp/app.py
@@ -1,5 +1,7 @@
 import os
 
+import pygame
+
 import sentry_sdk
 from kivy.app import App
 from kivy.config import Config
@@ -58,6 +60,8 @@ class MainApp(App):
 
     manager = ObjectProperty()
 
+    sound = ObjectProperty()
+
     version = StringProperty()
 
     def __init__(self, **kv):
@@ -65,9 +69,9 @@ class MainApp(App):
 
 
     def beep(self, *args, **kv):
-        pass
-        # self.sound.volume = self.formats.volume
-        # self.sound.play()
+        if self.sound and hasattr(self, "formats"):
+            self.sound.set_volume(self.formats.volume)
+            self.sound.play()
 
     @staticmethod
     def load_help(help_file_name):
@@ -94,6 +98,14 @@ class MainApp(App):
     def build(self):
         self.formats = FormatsDispatcher(id_override="0")
         self.board = Board(formats=self.formats, offset_provider=self)
+
+        # Load beep sound
+        sound_path = os.path.join(os.path.dirname(__file__), "sounds", "beep.mp3")
+        pygame.mixer.pre_init(frequency=44100, size=-16, channels=1, buffer=512)
+        pygame.init()
+        self.sound = pygame.mixer.Sound(sound_path)
+        if self.sound is None:
+            log.warning(f"Failed to load sound from {sound_path}")
 
         if not self.formats.disable_error_reporting:
             log.info("Error reporting is enabled, configuring Sentry")

--- a/rcp/components/home/coordbar.kv
+++ b/rcp/components/home/coordbar.kv
@@ -11,6 +11,7 @@
     text: root.axis.axis_name if root.axis else "?"
     font_size: min(self.height / 1.5, self.width/1.5)
     background_color: [0.2, 1, 0.2, 1] if (root.axis and root.axis.syncEnable) else [0.3, 0.3, 0.3, 1]
+    on_press: app.beep()
     on_release: root.toggle_sync()
 
   BoxLayout:
@@ -84,6 +85,7 @@
         text_size: self.size
         halign: 'center'
         valign: 'middle'
+        on_press: app.beep()
         on_release: Factory.Keypad(integer=True).show(root.axis, 'syncRatioNum') if root.axis else None
 
     BoxLayout:
@@ -108,6 +110,7 @@
         text_size: self.size
         halign: 'center'
         valign: 'middle'
+        on_press: app.beep()
         on_release: Factory.Keypad(integer=True).show(root.axis, 'syncRatioDen') if root.axis else None
 
   Button:
@@ -117,5 +120,7 @@
     background_color: [0.5, 0.5, 0.5, 1]
     width: self.height
     size_hint_x: None
-    on_press: root.on_zero_press()
+    on_press:
+      app.beep()
+      root.on_zero_press()
     on_release: root.on_zero_release()

--- a/rcp/components/home/dro_coordbar.kv
+++ b/rcp/components/home/dro_coordbar.kv
@@ -63,5 +63,7 @@
     background_color: [0.5, 0.5, 0.5, 1]
     width: self.height
     size_hint_x: None
-    on_press: root.on_zero_press()
+    on_press:
+      app.beep()
+      root.on_zero_press()
     on_release: root.on_zero_release()

--- a/rcp/components/home/els_mode_layout.kv
+++ b/rcp/components/home/els_mode_layout.kv
@@ -46,5 +46,7 @@
     background_color: [0.5, 0.5, 0.5, 1]
     width: self.height
     size_hint_x: None
-    on_press: root.on_zero_press()
+    on_press:
+      app.beep()
+      root.on_zero_press()
     on_release: root.on_zero_release()

--- a/rcp/components/home/elsbar.kv
+++ b/rcp/components/home/elsbar.kv
@@ -15,6 +15,7 @@
     font_size: self.height / 1.5
     font_style: "bold"
     background_color: [0.2, 1, 0.2, 1] if app.servo.servoEnable else [0.3, 0.3, 0.3, 1]
+    on_press: app.beep()
     on_release: app.servo.toggle_enable()
 
   BoxLayout:
@@ -55,6 +56,7 @@
     font_size: self.height / 4
     font_style: "bold"
     halign: "center"
+    on_press: app.beep()
     on_release: root.previous_feed()
 
   BoxLayout:
@@ -79,6 +81,7 @@
       text_size: self.size
       halign: 'center'
       valign: 'middle'
+      on_press: app.beep()
       on_release: Factory.FeedsTablePopup().show_with_callback(root.set_feed_ratio)
 
   Button:
@@ -90,4 +93,5 @@
     font_size: self.height / 4
     font_style: "bold"
     halign: "center"
+    on_press: app.beep()
     on_release: root.next_feed()

--- a/rcp/components/home/jogbar.kv
+++ b/rcp/components/home/jogbar.kv
@@ -12,6 +12,7 @@
     font_size: self.height / 1.5
     font_style: "bold"
     background_color: [0.2, 1, 0.2, 1] if app.servo.servoEnable else [0.3, 0.3, 0.3, 1]
+    on_press: app.beep()
     on_release: app.servo.toggle_enable()
     disabled: root.enable_jog
 
@@ -36,6 +37,7 @@
       text_size: self.size
       halign: 'center'
       valign: 'middle'
+      on_press: app.beep()
       on_release: Factory.Keypad().show(root, 'desired_speed')
     Label:
       text: "Max: {}".format(app.servo.maxSpeed)
@@ -105,7 +107,9 @@
     font_style: "bold"
     halign: "center"
     disabled: not app.servo.servoEnable
-    on_press: root.enable_jog_reverse = True
+    on_press:
+      app.beep()
+      root.enable_jog_reverse = True
     on_release: root.enable_jog_reverse = False
 
   Button:
@@ -118,6 +122,7 @@
     halign: "center"
     background_color: app.formats.cancel_color if root.enable_jog else app.formats.accept_color
     disabled: not app.servo.servoEnable
+    on_press: app.beep()
     on_release: root.enable_jog = not root.enable_jog
 
   Button:
@@ -129,5 +134,7 @@
     font_style: "bold"
     halign: "center"
     disabled: not app.servo.servoEnable
-    on_press: root.enable_jog = True
+    on_press:
+      app.beep()
+      root.enable_jog = True
     on_release: root.enable_jog = False

--- a/rcp/components/home/servobar.kv
+++ b/rcp/components/home/servobar.kv
@@ -13,6 +13,7 @@
     font_size: min(self.height / 1.5, self.width/1.5)
     font_style: "bold"
     background_color: [0.2, 1, 0.2, 1] if app.servo.servoEnable else [0.3, 0.3, 0.3, 1]
+    on_press: app.beep()
     on_release: app.servo.toggle_enable()
   BoxLayout:
     orientation: "vertical"
@@ -66,6 +67,7 @@
       halign: 'center'
       valign: 'middle'
       disabled: app.servo.disableControls
+      on_press: app.beep()
       on_release: Factory.Keypad().show(app.servo, 'offset')
 
     Label:
@@ -88,6 +90,7 @@
       halign: 'center'
       valign: 'middle'
       disabled: app.servo.disableControls
+      on_press: app.beep()
       on_release: Factory.Keypad(integer=True).show(app.servo, 'divisions')
 
   BoxLayout:
@@ -102,6 +105,7 @@
         font_name: "fonts/Font Awesome 6 Free-Solid-900.otf"
         text: "\uf060"
         disabled: app.servo.disableControls
+        on_press: app.beep()
         on_release: app.servo.go_previous()
       Button:
         font_size: 24
@@ -109,6 +113,7 @@
         font_name: "fonts/Font Awesome 6 Free-Solid-900.otf"
         text: "\uf061"
         disabled: app.servo.disableControls
+        on_press: app.beep()
         on_release: app.servo.go_next()
     BoxLayout:
       orientation: "vertical"
@@ -132,4 +137,5 @@
         halign: 'center'
         valign: 'middle'
         disabled: app.servo.disableControls
+        on_press: app.beep()
         on_release: Factory.Keypad(integer=True).show(app.servo, 'index')

--- a/rcp/components/plot/circle_popup.kv
+++ b/rcp/components/plot/circle_popup.kv
@@ -47,4 +47,5 @@
                 font_name: "fonts/Font Awesome 6 Free-Solid-900.otf"
                 text: "\uf00c"
                 background_color: "#349e65"
+                on_press: app.beep()
                 on_release: root.dismiss()

--- a/rcp/components/plot/line_popup.kv
+++ b/rcp/components/plot/line_popup.kv
@@ -43,4 +43,5 @@
                 font_name: "fonts/Font Awesome 6 Free-Solid-900.otf"
                 text: "\uf00c"
                 background_color: "#349e65"
+                on_press: app.beep()
                 on_release: root.dismiss()

--- a/rcp/components/plot/rect_popup.kv
+++ b/rcp/components/plot/rect_popup.kv
@@ -53,4 +53,5 @@
                 font_name: "fonts/Font Awesome 6 Free-Solid-900.otf"
                 text: "\uf00c"
                 background_color: "#349e65"
+                on_press: app.beep()
                 on_release: root.dismiss()

--- a/rcp/components/popups/feeds_table_popup.py
+++ b/rcp/components/popups/feeds_table_popup.py
@@ -6,11 +6,12 @@ from kivy.uix.button import Button
 from kivy.uix.tabbedpanel import TabbedPanel, TabbedPanelItem
 
 from rcp import feeds
+from rcp.components.widgets.beep_mixin import BeepMixin
 
 log = Logger.getChild(__name__)
 
 
-class FeedButton(Button):
+class FeedButton(BeepMixin, Button):
     text_halign = "center"
     font_style = "bold"
     font_name = StringProperty("fonts/Manrope-Bold.ttf")
@@ -53,10 +54,6 @@ class FeedsTablePopup(Popup):
         self.add_widget(panel)
         self.callback_fn = None
         self.current_value = None
-
-    def on_touch_down(self, touch):
-        self.app.beep()
-        return super().on_touch_down(touch)
 
     def show_with_callback(self, callback_fn, current_value=None):
         if current_value is not None:

--- a/rcp/components/popups/help_popup.kv
+++ b/rcp/components/popups/help_popup.kv
@@ -25,4 +25,5 @@
       size_hint_y: None
       height: 50
       text: "Close"
+      on_press: app.beep()
       on_release: root.dismiss()

--- a/rcp/components/popups/keypad.py
+++ b/rcp/components/popups/keypad.py
@@ -81,10 +81,6 @@ class Keypad(Popup):
     def on_current_value(self, instance, value):
         self.title = f"Old Value: {value}"
 
-    def on_touch_down(self, touch):
-        self.app.beep()
-        return super().on_touch_down(touch)
-
     def _keyboard_closed(self):
         self._keyboard.unbind(on_key_down=self._on_keyboard_down)
         self._keyboard = None

--- a/rcp/components/popups/mode_popup.py
+++ b/rcp/components/popups/mode_popup.py
@@ -29,10 +29,6 @@ class ModePopup(Popup):
         self.add_widget(buttons)
         self.callback_fn = None
 
-    def on_touch_down(self, touch):
-        self.app.beep()
-        return super().on_touch_down(touch)
-
     def show_with_callback(self, callback_fn, current_value=None):
         if current_value is not None:
             # Use the specified current value if passed

--- a/rcp/components/popups/ssid_popup.kv
+++ b/rcp/components/popups/ssid_popup.kv
@@ -22,6 +22,7 @@
         size_hint_x: 0.3
         text: "Scan"
         disabled: root.scanning
+        on_press: app.beep()
         on_release: root.schedule_scan()
 
     ScrollView:
@@ -44,10 +45,12 @@
         text: "Cancel"
         font_size: app.formats.font_size
         back_layer_color: app.formats.cancel_color
+        on_press: app.beep()
         on_release: root.dismiss()
 
       Button:
         text: "Apply"
         font_size: app.formats.font_size
         back_layer_color: app.formats.accept_color
+        on_press: app.beep()
         on_release: root.apply()

--- a/rcp/components/screens/axis_screen.kv
+++ b/rcp/components/screens/axis_screen.kv
@@ -82,9 +82,11 @@
         text: "Apply Transform"
         font_size: app.formats.font_size
         background_color: [0.2, 0.6, 0.2, 1]
+        on_press: app.beep()
         on_release: root.apply_transform()
       Button:
         text: "Remove Axis"
         font_size: app.formats.font_size
         background_color: [0.8, 0.2, 0.2, 1]
+        on_press: app.beep()
         on_release: root.remove_axis()

--- a/rcp/components/screens/color_picker_screen.kv
+++ b/rcp/components/screens/color_picker_screen.kv
@@ -19,12 +19,14 @@
         text: "Cancel"
         font_size: app.formats.font_size
         background_color: app.formats.cancel_color
+        on_press: app.beep()
         on_release: app.manager.back()
 
       Button:
         text: "Apply"
         font_size: app.formats.font_size
         background_color: app.formats.accept_color
+        on_press: app.beep()
         on_release:
           root.callback(root.color)
           app.manager.back()

--- a/rcp/components/screens/font_picker_screen.kv
+++ b/rcp/components/screens/font_picker_screen.kv
@@ -24,12 +24,14 @@
         text: "Cancel"
         font_size: app.formats.font_size
         background_color: app.formats.cancel_color
+        on_press: app.beep()
         on_release: app.manager.back()
 
       Button:
         text: "Apply"
         font_size: app.formats.font_size
         background_color: app.formats.accept_color
+        on_press: app.beep()
         on_release:
           root.callback(root.font_path)
           app.manager.back()

--- a/rcp/components/screens/formats_screen.kv
+++ b/rcp/components/screens/formats_screen.kv
@@ -97,7 +97,7 @@
           Button:
             size_hint_x: 0.2
             text: "Test"
-            on_release: app.beep()
+            on_press: app.beep()
           Slider:
             size_hint_x: 0.7
             min: 0

--- a/rcp/components/screens/home_screen.py
+++ b/rcp/components/screens/home_screen.py
@@ -82,10 +82,6 @@ class HomePage(Screen):
         if self.current_layout is not None:
             self.bars_container.add_widget(self.current_layout)
 
-    def on_touch_down(self, touch):
-        self.app.beep()
-        return super().on_touch_down(touch)
-
     def _keyboard_closed(self):
         self._keyboard.unbind(on_key_down=self._on_keyboard_down)
         self._keyboard = None

--- a/rcp/components/screens/setup_screen.kv
+++ b/rcp/components/screens/setup_screen.kv
@@ -2,6 +2,7 @@
 
 <SetupButton@Button>:
   font_size: app.formats.font_size
+  on_press: app.beep()
 
 <SetupScreen>:
   BoxLayout:

--- a/rcp/components/screens/update_screen.kv
+++ b/rcp/components/screens/update_screen.kv
@@ -54,9 +54,11 @@
           Button:
             text: "Install Selected Release"
             disabled: not root.enable_update_button
+            on_press: app.beep()
             on_release: root.install_release()
           Button:
             text: "Exit Application"
+            on_press: app.beep()
             on_release: app.stop()
 
         TitleItem:

--- a/rcp/components/setup/logs_panel.kv
+++ b/rcp/components/setup/logs_panel.kv
@@ -16,6 +16,7 @@
       width: 200
       text: "Refresh"
       font_size: app.formats.font_size
+      on_press: app.beep()
       on_release: root.refresh_logs()
 
   ScrollView:

--- a/rcp/components/setup/profiling_panel.kv
+++ b/rcp/components/setup/profiling_panel.kv
@@ -49,10 +49,12 @@
       text: "Stop Profiling" if root.is_profiling else "Start Profiling"
       font_size: 22
       background_color: (0.8, 0.2, 0.2, 1) if root.is_profiling else (0.2, 0.6, 0.2, 1)
+      on_press: app.beep()
       on_release: root.toggle_profiling()
     Button:
       text: "Reset Stats"
       font_size: 22
+      on_press: app.beep()
       on_release: root.reset_stats()
 
   # Status

--- a/rcp/components/toolbars/image_button.py
+++ b/rcp/components/toolbars/image_button.py
@@ -2,11 +2,12 @@ from kivy.logger import Logger
 from kivy.properties import StringProperty
 from kivy.uix.button import Button
 
+from rcp.components.widgets.beep_mixin import BeepMixin
 from rcp.utils.kv_loader import load_kv
 
 log = Logger.getChild(__name__)
 load_kv(__file__)
 
 
-class ImageButton(Button):
+class ImageButton(BeepMixin, Button):
     source = StringProperty("pictures/half-icon-white.png")

--- a/rcp/components/toolbars/led_button.py
+++ b/rcp/components/toolbars/led_button.py
@@ -3,13 +3,14 @@ from kivy.properties import BooleanProperty, StringProperty, ColorProperty
 from kivy.uix.behaviors import ButtonBehavior
 from kivy.uix.boxlayout import BoxLayout
 
+from rcp.components.widgets.beep_mixin import BeepMixin
 from rcp.utils.kv_loader import load_kv
 
 log = Logger.getChild(__name__)
 load_kv(__file__)
 
 
-class LedButton(ButtonBehavior, BoxLayout):
+class LedButton(BeepMixin, ButtonBehavior, BoxLayout):
     label = StringProperty()
     checkbox_value = BooleanProperty()
     current_color = ColorProperty((0, 0, 0, 1))

--- a/rcp/components/toolbars/toolbar_button.py
+++ b/rcp/components/toolbars/toolbar_button.py
@@ -1,13 +1,14 @@
 from kivy.logger import Logger
 from kivy.uix.button import Button
 
+from rcp.components.widgets.beep_mixin import BeepMixin
 from rcp.utils.kv_loader import load_kv
 
 log = Logger.getChild(__name__)
 load_kv(__file__)
 
 
-class ToolbarButton(Button):
+class ToolbarButton(BeepMixin, Button):
     pass
     # font_name = StringProperty("fonts/Manrope-Bold.ttf")
     # font_size = NumericProperty(36)

--- a/rcp/components/widgets/auto_size_button.py
+++ b/rcp/components/widgets/auto_size_button.py
@@ -2,8 +2,10 @@ from kivy.core.text import Label as CoreLabel
 from kivy.properties import NumericProperty
 from kivy.uix.button import Button
 
+from rcp.components.widgets.beep_mixin import BeepMixin
 
-class AutoSizeButton(Button):
+
+class AutoSizeButton(BeepMixin, Button):
     """Button that automatically scales font_size down to prevent text wrapping.
 
     Set max_font_size to the desired font size. The actual font_size will be

--- a/rcp/components/widgets/beep_mixin.py
+++ b/rcp/components/widgets/beep_mixin.py
@@ -1,0 +1,6 @@
+class BeepMixin:
+    """Mixin for Kivy button widgets that plays the app beep sound on press."""
+
+    def on_press(self):
+        from rcp.app import MainApp
+        MainApp.get_running_app().beep()

--- a/rcp/components/widgets/boolean_item.kv
+++ b/rcp/components/widgets/boolean_item.kv
@@ -10,6 +10,7 @@
       font_size: 21
       text: "\uf129"
       disabled: not root.help_file
+      on_press: app.beep()
       on_release: Factory.HelpPopup.show_help(root.help_file)
     Label:
       size_hint_x: 0.7

--- a/rcp/components/widgets/button_item.kv
+++ b/rcp/components/widgets/button_item.kv
@@ -11,6 +11,7 @@
       font_size: 21
       text: "\uf129"
       disabled: not root.help_file
+      on_press: app.beep()
       on_release: Factory.HelpPopup.show_help(root.help_file)
     Label:
       size_hint_x: 0.7
@@ -21,4 +22,5 @@
       width: 250
       text: str(root.value)
       font_size: app.formats.font_size
+      on_press: app.beep()
       on_release: root.dispatch_release()

--- a/rcp/components/widgets/color_item.kv
+++ b/rcp/components/widgets/color_item.kv
@@ -12,6 +12,7 @@
       font_size: 21
       text: "\uf129"
       disabled: not root.help_file
+      on_press: app.beep()
       on_release: Factory.HelpPopup.show_help(root.help_file)
     Label:
       size_hint_x: 0.7
@@ -29,6 +30,7 @@
           Rectangle:
             pos: self.pos[0] + 4, self.pos[1] + 4
             size: self.size[0] - 9, self.size[1] - 8
+        on_press: app.beep()
         on_release:
           app.color_picker.callback = root.set_color
           app.color_picker.color = root.color

--- a/rcp/components/widgets/dropdown_item.kv
+++ b/rcp/components/widgets/dropdown_item.kv
@@ -11,6 +11,7 @@
       font_size: 21
       text: "\uf129"
       disabled: not root.help_file
+      on_press: app.beep()
       on_release: Factory.HelpPopup.show_help(root.help_file)
     Label:
       size_hint_x: 0.7
@@ -24,4 +25,5 @@
 #      multiline: False
 #      text: 'ON' if root.value else 'OFF'
 #      state: 'down' if root.value else 'normal'
+      on_press: app.beep()
       on_release: root.dropdown.open(self)

--- a/rcp/components/widgets/dual_number_item.kv
+++ b/rcp/components/widgets/dual_number_item.kv
@@ -11,6 +11,7 @@
       font_size: 21
       text: "\uf129"
       disabled: not root.help_file
+      on_press: app.beep()
       on_release: Factory.HelpPopup.show_help(root.help_file)
     Label:
       size_hint_x: 0.6
@@ -21,10 +22,12 @@
       width: 125
       text: "{: 0.4f}".format(root.value / root.ratio)
       font_size: app.formats.font_size
+      on_press: app.beep()
       on_release: Factory.Keypad().show(root, 'scaled_value')
     Button:
       size_hint_x: None
       width: 125
       text: "{: 0.4f}".format(root.value)
       font_size: app.formats.font_size
+      on_press: app.beep()
       on_release: Factory.Keypad().show(root, 'value')

--- a/rcp/components/widgets/font_item.kv
+++ b/rcp/components/widgets/font_item.kv
@@ -11,6 +11,7 @@
       font_size: 21
       text: "\uf129"
       disabled: not root.help_file
+      on_press: app.beep()
       on_release: Factory.HelpPopup.show_help(root.help_file)
     Label:
       size_hint_x: 0.7
@@ -23,6 +24,7 @@
       font_size: 22
       background_color: (0.25, 0.25, 0.25, 1)
       text: "+123.456"
+      on_press: app.beep()
       on_release:
         app.font_picker.callback = root.set_font
         app.font_picker.font_path = root.font_path

--- a/rcp/components/widgets/keypad_button.py
+++ b/rcp/components/widgets/keypad_button.py
@@ -2,13 +2,14 @@ from kivy.logger import Logger
 from kivy.uix.button import Button
 from kivy.properties import NumericProperty
 
+from rcp.components.widgets.beep_mixin import BeepMixin
 from rcp.utils.kv_loader import load_kv
 
 log = Logger.getChild(__name__)
 load_kv(__file__)
 
 
-class KeypadButton(Button):
+class KeypadButton(BeepMixin, Button):
     return_value = NumericProperty(0)
 
     def __init__(self, **kwargs):

--- a/rcp/components/widgets/keypad_icon_button.py
+++ b/rcp/components/widgets/keypad_icon_button.py
@@ -2,12 +2,13 @@ from kivy.logger import Logger
 from kivy.uix.button import Button
 from kivy.properties import NumericProperty
 
+from rcp.components.widgets.beep_mixin import BeepMixin
 from rcp.utils.kv_loader import load_kv
 
 log = Logger.getChild(__name__)
 load_kv(__file__)
 
-class KeypadIconButton(Button):
+class KeypadIconButton(BeepMixin, Button):
     return_value = NumericProperty(0)
 
     def __init__(self, **kwargs):

--- a/rcp/components/widgets/number_item.kv
+++ b/rcp/components/widgets/number_item.kv
@@ -11,6 +11,7 @@
       font_size: 21
       text: "\uf129"
       disabled: not root.help_file
+      on_press: app.beep()
       on_release: Factory.HelpPopup.show_help(root.help_file)
     Label:
       size_hint_x: 0.7
@@ -21,4 +22,5 @@
       width: 250
       text: str(root.value)
       font_size: app.formats.font_size
+      on_press: app.beep()
       on_release: Factory.Keypad(integer=root.integer).show(root, 'value')

--- a/rcp/components/widgets/screen_header.kv
+++ b/rcp/components/widgets/screen_header.kv
@@ -21,6 +21,7 @@
         width: 250
         text: "Back"
         font_size: app.formats.font_size
+        on_press: app.beep()
         on_release:
           app.manager.back()
     Widget:


### PR DESCRIPTION
This reenables the beep functionality.  It uses pygame, as with Kivy's SoundLoader I could not seem to eliminate a noticeable lag between button press and the sound playing.

This also switches away from using "on_touch_down" on the HomePage as a catch-all that caused it to beep when you touch anywhere at all, including empty spaces.  Instead the beep function is associated with each button (etc.), so it only beeps when you tap something actually interactive.