### PR TITLE
Feat: make display of speeds and wizard button on toolbar optional

### DIFF
--- a/rcp/components/home/coordbar.kv
+++ b/rcp/components/home/coordbar.kv
@@ -43,7 +43,13 @@
           valign: 'center'
       BoxLayout:
         orientation: "horizontal"
-        size_hint_y: 0.3
+
+        # Hide speed display if show_speeds is False
+        size_hint_y: 0.3 if app.formats.show_speeds else None
+        height: self.height if app.formats.show_speeds else 0
+        opacity: 1 if app.formats.show_speeds else 0
+        disabled: not app.formats.show_speeds
+
         Label:
           font_name: app.formats.font_name
           font_size: self.height / 1.5

--- a/rcp/components/home/dro_coordbar.kv
+++ b/rcp/components/home/dro_coordbar.kv
@@ -37,7 +37,13 @@
         valign: 'center'
     BoxLayout:
       orientation: "horizontal"
-      size_hint_y: 0.3
+
+      # Hide speed display if show_speeds is False
+      size_hint_y: 0.3 if app.formats.show_speeds else None
+      height: self.height if app.formats.show_speeds else 0
+      opacity: 1 if app.formats.show_speeds else 0
+      disabled: not app.formats.show_speeds
+
       Label:
         font_name: app.formats.font_name
         font_size: self.height / 1.5

--- a/rcp/components/home/dro_mode_layout.py
+++ b/rcp/components/home/dro_mode_layout.py
@@ -14,6 +14,7 @@ class DroModeLayout(ModeLayout):
         self.add_widget(self.spacer)
 
         self.app.formats.bind(max_row_height=lambda *_: self._update_row_heights())
+        self.app.formats.bind(show_speeds=lambda *_: self.rebuild_axes())
         self.bind(height=self._update_row_heights)
         self._update_row_heights()
 
@@ -35,3 +36,9 @@ class DroModeLayout(ModeLayout):
             cb = DroCoordBar(axis=axis_disp)
             self.axis_bars.append(cb)
             self.add_widget(cb)
+
+    def rebuild_axes(self):
+        self.remove_widget(self.spacer)
+        super().rebuild_axes()
+        self.add_widget(self.spacer)
+        self._update_row_heights()

--- a/rcp/components/home/els_mode_layout.py
+++ b/rcp/components/home/els_mode_layout.py
@@ -98,6 +98,7 @@ class ElsModeLayout(ModeLayout):
         )
 
         self.app.formats.bind(max_row_height=lambda *_: self._update_row_heights())
+        self.app.formats.bind(show_speeds=lambda *_: self.rebuild_axes())
         self.bind(height=self._update_row_heights)
         self._update_row_heights()
 

--- a/rcp/components/home/home_toolbar.kv
+++ b/rcp/components/home/home_toolbar.kv
@@ -13,35 +13,52 @@
     width: root.width
     text: app.formats.current_format
     on_release: app.formats.toggle()
+    size_hint_y: 1
+    font_size: min(self.height/3, self.width/3)
 
   ToolbarButton:
     width: root.width
     text: "P{:d}".format(app.currentOffset)
     on_release: Factory.Keypad().show(app, 'currentOffset')
+    size_hint_y: 1
+    font_size: min(self.height/3, self.width/3)
 
   ToolbarButton:
     width: root.width
     text: "ABS" if app.abs_mode else "INC"
     background_color: (list(app.formats.color_on) if app.board.blink else [1, 1, 1, 1]) if app.abs_mode else [1, 1, 1, 1]
     on_release: app.abs_mode = not app.abs_mode
+    size_hint_y: 1
+    font_size: min(self.height/3, self.width/3)
 
   ToolbarButton:
     width: root.width
     font_name: "fonts/Font Awesome 6 Free-Solid-900.otf"
     text: "\ue2ca"
     on_press: app.manager.goto("plot")
+    font_size: min(self.height/3, self.width/3)
+
+    # Hide wizard button if show_wizard is False
+    size_hint_y: 1 if app.formats.show_wizard else None
+    height: self.height if app.formats.show_wizard else 0
+    opacity: 1 if app.formats.show_wizard else 0
+    disabled: not app.formats.show_wizard
 
   ToolbarButton:
     width: root.width
     text: root.current_mode_desc
     on_release:
       Factory.ModePopup().show_with_callback(app.set_mode, app.current_mode)
+    size_hint_y: 1
+    font_size: min(self.height/3, self.width/3)
 
   ToolbarButton:
     width: root.width
     font_name: "fonts/Font Awesome 6 Free-Solid-900.otf"
     text: "\uf085"
     on_press: app.manager.goto("setup_screen")
-
-  Widget:
     size_hint_y: 1
+    font_size: min(self.height/3, self.width/3)
+
+  #Widget:
+  #  size_hint_y: 1

--- a/rcp/components/home/index_mode_layout.py
+++ b/rcp/components/home/index_mode_layout.py
@@ -17,6 +17,7 @@ class IndexModeLayout(ModeLayout):
         self.add_widget(self.servo_bar)
 
         self.app.formats.bind(max_row_height=lambda *_: self._update_row_heights())
+        self.app.formats.bind(show_speeds=lambda *_: self.rebuild_axes())
         self.bind(height=self._update_row_heights)
         self._update_row_heights()
 
@@ -27,9 +28,12 @@ class IndexModeLayout(ModeLayout):
             self.add_widget(cb)
 
     def rebuild_axes(self):
+        self.remove_widget(self.spacer)
         self.remove_widget(self.servo_bar)
         super().rebuild_axes()
+        self.add_widget(self.spacer)
         self.add_widget(self.servo_bar)
+        self._update_row_heights()
 
     def _update_row_heights(self, *args):
         num_rows = len(self.axis_bars)

--- a/rcp/components/home/jog_mode_layout.py
+++ b/rcp/components/home/jog_mode_layout.py
@@ -16,6 +16,7 @@ class JogModeLayout(ModeLayout):
         self.add_widget(self.jog_bar)
 
         self.app.formats.bind(max_row_height=lambda *_: self._update_row_heights())
+        self.app.formats.bind(show_speeds=lambda *_: self.rebuild_axes())
         self.bind(height=self._update_row_heights)
         self._update_row_heights()
 
@@ -26,9 +27,12 @@ class JogModeLayout(ModeLayout):
             self.add_widget(cb)
 
     def rebuild_axes(self):
+        self.remove_widget(self.spacer)
         self.remove_widget(self.jog_bar)
         super().rebuild_axes()
+        self.add_widget(self.spacer)
         self.add_widget(self.jog_bar)
+        self._update_row_heights()
     
     def _update_row_heights(self, *args):
         num_rows = len(self.axis_bars)

--- a/rcp/components/screens/formats_screen.kv
+++ b/rcp/components/screens/formats_screen.kv
@@ -91,6 +91,10 @@
           name: "Max axis row height (px)"
           value: root.formats.max_row_height
           on_value: root.formats.max_row_height = self.value
+        BooleanItem:
+          name: "Show Speeds"
+          value: root.formats.show_speeds
+          on_value: root.formats.show_speeds = self.value
 
         TitleItem:
           name: "Sound Settings"

--- a/rcp/components/screens/formats_screen.kv
+++ b/rcp/components/screens/formats_screen.kv
@@ -95,6 +95,10 @@
           name: "Show Speeds"
           value: root.formats.show_speeds
           on_value: root.formats.show_speeds = self.value
+        BooleanItem:
+          name: "Show Wizard"
+          value: root.formats.show_wizard
+          on_value: root.formats.show_wizard = self.value
 
         TitleItem:
           name: "Sound Settings"

--- a/rcp/dispatchers/formats.py
+++ b/rcp/dispatchers/formats.py
@@ -55,6 +55,8 @@ class FormatsDispatcher(SavingDispatcher):
 
     show_speeds = BooleanProperty(True)
 
+    show_wizard = BooleanProperty(True)
+
     def __init__(self, **kv):
         super().__init__(**kv)
         self.angle_speed_format = self.angle_speed_format.replace("RPM", "").replace(" ", "")

--- a/rcp/dispatchers/formats.py
+++ b/rcp/dispatchers/formats.py
@@ -53,6 +53,8 @@ class FormatsDispatcher(SavingDispatcher):
 
     max_row_height = NumericProperty(150)
 
+    show_speeds = BooleanProperty(True)
+
     def __init__(self, **kv):
         super().__init__(**kv)
         self.angle_speed_format = self.angle_speed_format.replace("RPM", "").replace(" ", "")


### PR DESCRIPTION
This adds options to the format settings menu to disable the display of axis velocities, and disable the "wizard" button on the left toolbar.  

Personally, I'd prefer to hide velocities when I don't need them (which I think will be most of the time) to reduce visual distraction from all the extra digits changing on the screen.

The "wizard" button and associated plot view screen are really mill-centric, so for use on a lathe it would be preferable to hide the button.

Both hidden:
<img width="1495" height="1146" alt="image" src="https://github.com/user-attachments/assets/6a447b0b-5acf-4bd3-9643-e772171954d1" />